### PR TITLE
fix(types): remove superfluous extend (fixes #85)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ deno_dist/
 
 # VSCode suggestions
 !.vscode
+
+tsconfig.vitest-temp.json

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "dev": "tsup --watch",
     "format": "prettier --write \"{,!(node_modules|dist|coverage)/**/}*.{ts,tsx,js,jsx,md,yml,json}\"",
     "prepare": "husky install",
-    "test": "vitest",
+    "test": "vitest --typecheck",
     "validate": "pnpm run check-types && pnpm test run -- --coverage"
   },
   "config": {

--- a/src/index.test-d.ts
+++ b/src/index.test-d.ts
@@ -1,0 +1,40 @@
+import { describe, it, expectTypeOf } from "vitest";
+import {
+  formAtom,
+  fieldAtom,
+  type FieldAtom,
+  type FormValues,
+  type FormErrors,
+} from ".";
+
+describe("FormValues", () => {
+  it("works with array", () => {
+    const hobbiesFormAtom = formAtom<{
+      hobbies: Array<{
+        name: FieldAtom<string>;
+      }>;
+    }>({
+      hobbies: [{ name: fieldAtom({ value: "jumping rope" }) }],
+    });
+
+    expectTypeOf<FormValues<typeof hobbiesFormAtom>>().toEqualTypeOf<{
+      hobbies: { name: string }[];
+    }>();
+  });
+});
+
+describe("FormErrors", () => {
+  it("works with array", () => {
+    const hobbiesFormAtom = formAtom<{
+      hobbies: Array<{
+        name: FieldAtom<string>;
+      }>;
+    }>({
+      hobbies: [{ name: fieldAtom({ value: "jumping rope" }) }],
+    });
+
+    expectTypeOf<FormErrors<typeof hobbiesFormAtom>>().toEqualTypeOf<{
+      hobbies: { name: string[] }[];
+    }>();
+  });
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1646,7 +1646,7 @@ export type FormFields = {
  * type NameFormValues = FormValues<typeof nameForm>
  * ```
  */
-export type FormValues<Form extends FormAtom<any>> =
+export type FormValues<Form> =
   Form extends FormAtom<infer Fields> ? FormFieldValues<Fields> : never;
 
 /**
@@ -1661,7 +1661,7 @@ export type FormValues<Form extends FormAtom<any>> =
  * type NameFormErrors = FormErrors<typeof nameForm>
  * ```
  */
-export type FormErrors<Form extends FormAtom<any>> =
+export type FormErrors<Form> =
   Form extends FormAtom<infer Fields> ? FormFieldErrors<Fields> : never;
 
 /**


### PR DESCRIPTION
The `<any>` expansion prevented the type to initialize. No need to have it in the generic position, as it is checked in the conditional type where Fields inference happens.

Closes #85 